### PR TITLE
Fix missing alias name for prefixed tables

### DIFF
--- a/src/elements/db/NodeQuery.php
+++ b/src/elements/db/NodeQuery.php
@@ -75,7 +75,7 @@ class NodeQuery extends ElementQuery
     protected function beforePrepare(): bool
     {
         $this->joinElementTable('navigation_nodes');
-        $this->subQuery->innerJoin('{{%navigation_navs}}', '[[navigation_nodes.navId]] = [[navigation_navs.id]]');
+        $this->subQuery->innerJoin('{{%navigation_navs}} navigation_navs', '[[navigation_nodes.navId]] = [[navigation_navs.id]]');
 
         $this->query->select([
             'navigation_nodes.*',


### PR DESCRIPTION
Hi,
I just wanted to try out your plugin to maybe buy it for an upcoming project.
After the plugin installation I set up a Navigation and when I wanted to open it in the CP to add nodes, I experienced an SQL error:
```
Database Exception – yii\db\Exception
SQLSTATE[42S22]: Column not found: 1054 Unknown column 'navigation_navs.id' in 'on clause'
The SQL being executed was: SELECT `elements`.`id`, `elements`.`fieldLayoutId`, `elements`.`uid`, `elements`.`enabled`, `elements`.`archived`, `elements`.`dateCreated`, `elements`.`dateUpdated`, `elements_sites`.`slug`, `elements_sites`.`uri`, `elements_sites`.`enabled` AS `enabledForSite`, `navigation_nodes`.*, `content`.`id` AS `contentId`, `content`.`title`, ........ , `structureelements`.`root`, `structureelements`.`lft`, `structureelements`.`rgt`, `structureelements`.`level`, `structureelements`.`structureId`
FROM (SELECT `elements`.`id` AS `elementsId`, `elements_sites`.`id` AS `elementsSitesId`, `content`.`id` AS `contentId`
FROM `at52s_elements` `elements`
INNER JOIN `at52s_navigation_nodes` `navigation_nodes` ON `navigation_nodes`.`id` = `elements`.`id`
INNER JOIN `at52s_navigation_navs` ON `navigation_nodes`.`navId` = `navigation_navs`.`id`
INNER JOIN `at52s_elements_sites` `elements_sites` ON `elements_sites`.`elementId` = `elements`.`id`
INNER JOIN `at52s_content` `content` ON `content`.`elementId` = `elements`.`id`
LEFT JOIN `at52s_structureelements` `structureelements` ON `structureelements`.`elementId` = `elements`.`id`
WHERE (`navigation_nodes`.`navId`=1) AND (`elements_sites`.`siteId`=1) AND (`content`.`siteId`=1) AND (`elements`.`archived`=FALSE) AND (`elements_sites`.`enabled`=TRUE)
ORDER BY `structureelements`.`lft`, `elements`.`dateCreated` DESC) `subquery`
INNER JOIN `at52s_navigation_nodes` `navigation_nodes` ON `navigation_nodes`.`id` = `subquery`.`elementsId`
INNER JOIN `at52s_elements` `elements` ON `elements`.`id` = `subquery`.`elementsId`
INNER JOIN `at52s_elements_sites` `elements_sites` ON `elements_sites`.`id` = `subquery`.`elementsSitesId`
INNER JOIN `at52s_content` `content` ON `content`.`id` = `subquery`.`contentId`
LEFT JOIN `at52s_structureelements` `structureelements` ON `structureelements`.`elementId` = `subquery`.`elementsId`
ORDER BY `structureelements`.`lft`, `elements`.`dateCreated` DESC
Error Info: Array
(
    [0] => 42S22
    [1] => 1054
    [2] => Unknown column 'navigation_navs.id' in 'on clause'
)
↵
Caused by: PDOException
SQLSTATE[42S22]: Column not found: 1054 Unknown column 'navigation_navs.id' in 'on clause'
in /home/httpd/vhosts/......../vendor/yiisoft/yii2/db/Command.php at line 1258
```

In the line
```
INNER JOIN `at52s_navigation_navs` ON `navigation_nodes`.`navId` = `navigation_navs`.`id`
```
You can see, that the table alias name is missing unlike in the other lines.

This PR  adds the alias.

Cheers! 😉 