### PR TITLE
Fix render bug

### DIFF
--- a/src/variables/NavigationVariable.php
+++ b/src/variables/NavigationVariable.php
@@ -47,5 +47,7 @@ class NavigationVariable
             'nodes' => $nodes,
             'options' => $options,
         ]);
+        
+        Craft::$app->view->setTemplateMode(View::TEMPLATE_MODE_SITE);
     }
 }


### PR DESCRIPTION
Fix bug where templates using the render method could not thereafter use {% include %} (or possibly other tags etc requiring paths) as Craft was still in 'cp' mode, so all templates were starting from the 'wrong' base path.