### PR TITLE
JS strings should be translated

### DIFF
--- a/src/resources/src/js/navigation.js
+++ b/src/resources/src/js/navigation.js
@@ -311,8 +311,8 @@ Craft.Navigation.Editor = Garnish.Base.extend({
             var $footer = $('<div class="hud-footer"/>').appendTo(this.$form),
                 $buttonsContainer = $('<div class="buttons right"/>').appendTo($footer);
 
-            this.$cancelBtn = $('<div class="btn">' + Craft.t('navigation', 'Cancel') + '</div>').appendTo($buttonsContainer);
-            this.$saveBtn = $('<input class="btn submit" type="submit" value="' + Craft.t('navigation', 'Save') + '"/>').appendTo($buttonsContainer);
+            this.$cancelBtn = $('<div class="btn">' + Craft.t('app', 'Cancel') + '</div>').appendTo($buttonsContainer);
+            this.$saveBtn = $('<input class="btn submit" type="submit" value="' + Craft.t('app', 'Save') + '"/>').appendTo($buttonsContainer);
             this.$spinner = $('<div class="spinner left hidden"/>').appendTo($buttonsContainer);
 
             $hudContents = $hudContents.add(this.$form);

--- a/src/translations/hu/navigation.php
+++ b/src/translations/hu/navigation.php
@@ -62,4 +62,10 @@ return [
 
     // Crumbs label - global
     'Navigations' => 'Menük',
+
+    // vendor/verbb/navigation/src/resources/src/js/navigation.js
+    'Node added.' => 'Menüpont hozzáadva.',
+    'Node deleted.' => 'Menüpont törölve.',
+    'Node updated.' => 'Menüpont frissítve',
+    'Are you sure you want to delete “{title}” and its descendants?' => 'Biztosan törölni szeretnéd “{title}” menüpontot és minden gyermekét?'
 ];


### PR DESCRIPTION
This is strange: I added the string to the usual navigation.php translation file, but strings like 'Node deleted.' don't use the translated string.