### PR TITLE
Trim trailing slash in getActive method when addTrailingSlashesToUrls

### DIFF
--- a/src/elements/Node.php
+++ b/src/elements/Node.php
@@ -125,6 +125,11 @@ class Node extends Element
             return false;
         }
 
+        // If addTrailingSlashesToUrls, remove trailing '/' for comparison
+        if (Craft::$app->config->general->addTrailingSlashesToUrls) {
+            $relativeUrl = rtrim($relativeUrl, '/');
+        }
+
         // If manual URL, make sure to remove a leading '/' for comparison
         if ($this->isManual()) {
             $relativeUrl = ltrim($relativeUrl, '/');


### PR DESCRIPTION
Enabling _addTrailingSlashesToUrls_ in Craft 3's _general.php_ causes the _getActive_ comparison to fail. Added a similar modification as the _isManual_ check where a slash is removed - in this case the trailing slash.