### PR TITLE
Adds  #34

### DIFF
--- a/src/controllers/NavsController.php
+++ b/src/controllers/NavsController.php
@@ -47,11 +47,17 @@ class NavsController extends Controller
 
     public function actionBuildNav(int $navId = null, string $siteHandle = null)
     {
+        $storedSiteId = Craft::$app->getRequest()->getParam('storedSiteId');
         if ($siteHandle === null) {
             $siteHandle = Craft::$app->getSites()->getCurrentSite()->handle;
         }
 
-        $site = Craft::$app->getSites()->getSiteByHandle($siteHandle);
+        // Undefined localstorage will be submitted as null in string variant.
+        if ($storedSiteId && $storedSiteId !== 'null') {
+            $site = Craft::$app->getSites()->getSiteById($storedSiteId);
+        } else {
+            $site = Craft::$app->getSites()->getSiteByHandle($siteHandle);
+        }
 
         if (!$site) {
             throw new NotFoundHttpException('Invalid site handle: ' . $siteHandle);

--- a/src/resources/src/js/navigation.js
+++ b/src/resources/src/js/navigation.js
@@ -350,7 +350,7 @@ Craft.Navigation.Editor = Garnish.Base.extend({
 
                 this.$node.parent().data('label', response.node.title);
                 this.$node.parent().find('.title').text(response.node.title);
-                
+
                 if (response.node.enabled && response.node.enabledForSite) {
                     $status.addClass('enabled');
                     $status.removeClass('disabled');
@@ -388,7 +388,7 @@ function generateSelect(options) {
         $(element).html(html);
         $(element).val(selected);
     });
-    
+
 }
 
 

--- a/src/templates/navs/_build.html
+++ b/src/templates/navs/_build.html
@@ -168,7 +168,11 @@
 </script>
 
 {% js %}
-    new Craft.Navigation({{ nav | json_encode | raw }}, {
+
+// Update the local storage.
+localStorage.setItem('Craft-'+ Craft.systemUid +'.BaseElementIndex.siteId', {{ site.id }});
+
+new Craft.Navigation({{ nav | json_encode | raw }}, {
         siteId: {{ site.id }},
     });
 {% endjs %}

--- a/src/templates/navs/index.html
+++ b/src/templates/navs/index.html
@@ -17,6 +17,7 @@
 {% endblock %}
 
 {% block content %}
+
     <p id="nonavigations"{% if navigations | length %} class="hidden"{% endif %}>
         {{ "No navigations exist yet." | t('navigation') }}
     </p>
@@ -34,7 +35,7 @@
             <tbody>
                 {% for navigation in navigations %}
                     <tr data-id="{{ navigation.id }}" data-name="{{ navigation.name | t('site') }}">
-                        <th scope="row" data-title="{{ 'Name' | t('app') }}"><a href="{{ url('navigation/navs/build/' ~ navigation.id) }}">{{ navigation.name | t('app') }}</a></th>
+                        <th scope="row" data-title="{{ 'Name' | t('app') }}"><a class="navanchor" href="{{ url('navigation/navs/build/' ~ navigation.id) }}">{{ navigation.name | t('app') }}</a></th>
 
                         <td scope="row" data-title="{{ 'Handle' | t('app') }}" class="code">{{ navigation.handle }}</td>
 
@@ -50,6 +51,17 @@
 {% endblock %}
 
 {% js %}
+    // Get the local storage and add the storedSiteid param to the URL's.
+    $(".navanchor").each(function() {
+        var $this = $(this);
+        var _href = $this.attr("href");
+        var localKey = localStorage.getItem('Craft-'+ Craft.systemUid +'.BaseElementIndex.siteId');
+        if (localKey !== null) {
+            $this.attr("href", _href + '&storedSiteId='+ localKey +'');
+        }
+    });
+
+
     var adminTable = new Craft.AdminTable({
         tableSelector: '#navigations',
         noItemsSelector: '#nonavigations',


### PR DESCRIPTION
Adds support for detecting and updating the site id based on site selection option made when editing entries. See issue #34 for more info. 

Does the following things: 

- Adds a get param `&storedSiteId=` to the end of the URL on the navigation index page based on what id is set in [localStorage().](https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage) If nothing is there it doesnt add a param. 

- Checks at controller level if a `storedSiteId ` was sent and gets the corresponding site. 

- Updates the localStorage of the user if they change site when editing/building a navigation. 

