### PR TITLE
Bugfix: Query string variable adjustment.

### DIFF
--- a/src/templates/navs/index.html
+++ b/src/templates/navs/index.html
@@ -57,7 +57,7 @@
         var _href = $this.attr("href");
         var localKey = localStorage.getItem('Craft-'+ Craft.systemUid +'.BaseElementIndex.siteId');
         if (localKey !== null) {
-            $this.attr("href", _href + '&storedSiteId='+ localKey +'');
+            $this.attr("href", _href + '?storedSiteId='+ localKey +'');
         }
     });
 


### PR DESCRIPTION
Change from & to ? for storedSideId query string var.
This was causing 404 template not found errors in the craft CP.