### PR TITLE
Fix type mismatch error on PostgreSQL

### DIFF
--- a/src/services/Nodes.php
+++ b/src/services/Nodes.php
@@ -50,7 +50,7 @@ class Nodes extends Component
         $nodes = NodeElement::find()
             ->elementId($element->id)
             ->siteId($element->siteId)
-            ->slug($element->siteId)
+            ->slug((string) $element->siteId)
             ->status(null)
             ->type(get_class($element))
             ->all();


### PR DESCRIPTION
"slug" is a varchar field, and thus should query by string in stead of integer