### PR TITLE
Fix double escaping of nav titles in vue tables

### DIFF
--- a/src/templates/navs/index.html
+++ b/src/templates/navs/index.html
@@ -29,7 +29,7 @@
 {% for navigation in navigations %}
     {% set tableData = tableData | merge([{
         id: navigation.id,
-        title: navigation.name | t('site') | e,
+        title: navigation.name | t('site'),
         url: url('navigation/navs/build/' ~ navigation.id),
         name: navigation.name | t('site') | e,
         handle: navigation.handle,


### PR DESCRIPTION
As per bug discovered in Craft (https://github.com/craftcms/cms/issues/5532). This fixes double escaping in navigation titles when shown in Vue admin tables, which results in `&` being displayed as `&amp;` for example.