### PR TITLE
Use getBaseUrl() for parsing Site node type URLs. Fixes #146.

### DIFF
--- a/src/nodetypes/SiteType.php
+++ b/src/nodetypes/SiteType.php
@@ -54,7 +54,7 @@ class SiteType extends NodeType
             if ($siteId) {
                 if ($site = Craft::$app->getSites()->getSiteById($siteId)) {
                     if ($site->hasUrls) {
-                        return $site->baseUrl;
+                        return $site->getBaseUrl();
                     }
                 }
             }


### PR DESCRIPTION
Needed more internet points. Tested locally and seems to do the trick!