### PR TITLE
Fix an error when saving settings for the first time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.4.19 - 2021-06-23
+
+### Fixed
+- Fix an error when saving settings for the first time
+
 ## 1.4.18 - 2021-06-20
 
 ### Fixed

--- a/src/services/Navs.php
+++ b/src/services/Navs.php
@@ -318,9 +318,11 @@ class Navs extends Component
             $newSiteSettings = Json::decode($navRecord->siteSettings);
 
             // Removed sites
-            foreach ($oldSiteSettings as $key => $value) {
-                if (!isset($newSiteSettings[$key])) {
-                    // Nothing for now
+            if ($oldSiteSettings) {
+                foreach ($oldSiteSettings as $key => $value) {
+                    if (!isset($newSiteSettings[$key])) {
+                        // Nothing for now
+                    }
                 }
             }
 


### PR DESCRIPTION
Fixes issues that occur when saving settings for the first time or when applying settings via project config for the first time:

```


Exception 'craft\errors\MigrationException' with message 'An error occurred while executing the "craft\migrations\Install migration: foreach() argument must be of type array\|object, null given'
--
  |  
  | in /app/user/vendor/craftcms/cms/src/db/MigrationManager.php:252
  |  
  | Caused by: PHP Warning 'yii\base\ErrorException' with message 'foreach() argument must be of type array\|object, null given'
  |  
  | in /app/user/vendor/verbb/navigation/src/services/Navs.php:321


```