### PR TITLE
Missing namespace causes errors on import with Feedme

### DIFF
--- a/src/integrations/NodeFeedMeElement.php
+++ b/src/integrations/NodeFeedMeElement.php
@@ -6,6 +6,7 @@ use verbb\navigation\elements\Node;
 
 use Craft;
 use craft\base\ElementInterface;
+use craft\db\Query;
 use craft\helpers\Json;
 
 use craft\feedme\Plugin;


### PR DESCRIPTION
Adds in a missing `use craft\db\Query;` to address the error `Class "verbb\navigation\integrations\Query" not found - NodeFeedMeElement.php: 131.` when importing with Feedme.